### PR TITLE
updated readme to point to the Openshift feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This repo is intended for tracking issues with Azure Red Hat Openshift (ARO). It is monitored by the ARO product team. For direct customer support, please take a look at the [Azure Support options](https://azure.microsoft.com/support/options/). Note that the following channels are also monitored and should be used as suggested:
 
-- Updates about the service, including new features and new Azure regions: [OpenShift feed in Azure Updates](https://azure.microsoft.com/updates/?product=kubernetes-service)
+- Updates about the service, including new features and new Azure regions: [OpenShift feed in Azure Updates](https://azure.microsoft.com/en-gb/updates/?product=openshift)
 
 ## Code of conduct
 


### PR DESCRIPTION
Fixes the documentation issue pointing to AKS update feed instead of OpenShift. Closes issue #106